### PR TITLE
Update SsTwitterFeedVariable.php

### DIFF
--- a/src/variables/SsTwitterFeedVariable.php
+++ b/src/variables/SsTwitterFeedVariable.php
@@ -97,6 +97,7 @@ class SsTwitterFeedVariable
                                 'favorite_count' => isset( $row->favorite_count ) ? $row->favorite_count:null,                     
                                 'created_at'     => $this->time_ago( $row->created_at ),
                                 'tweet_date'     => isset( $row->created_at ) ? $row->created_at:null,
+                                'tweet_id'       => $row->id_str,
                                 'retweet_link'  => 'https://twitter.com/intent/retweet?tweet_id='.$row->id_str,
                                 'favorite_link'  => 'https://twitter.com/intent/like?tweet_id='.$row->id_str,
                             );


### PR DESCRIPTION
It looks like `{{ tweet.url }}` outputs null unless the tweet contains a link, in which case it's the linked URL. I expected this to output the URL to the tweet so that I could link `created_at` to the original tweet. I solved for this by adding `tweet_id` to the Twig variable's output, so I can use that to create a URL to the tweet in my template.