### PR TITLE
Fix example for `exclude_retweets` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Just click on button get your Twitter Access Token and Twitter Secret.
 -You can directly access multidimensional array of your Twitter posts using following method.
 Each post has Following components you can get to:
 
-- If you wish exclude retweet, Just pass parameter like craft.ssTwitterFeed.displayPost( '5', 'exclude_retweets' ).
+- If you wish exclude retweet, Just pass parameter like `craft.ssTwitterFeed.displayPost( '5', true )`.
 - Multiple images array of your twitter.
 
 <ul>


### PR DESCRIPTION
Hey, I noticed a little bug in the README. I could only exclude retweets by actually passing `true`, not just a string.

This PR fixes the example and formats it as inline code.